### PR TITLE
allow posts with attachments only (posts without text)

### DIFF
--- a/Hikkaba.Web/Controllers/Mvc/PostController.cs
+++ b/Hikkaba.Web/Controllers/Mvc/PostController.cs
@@ -104,13 +104,13 @@ public sealed class PostController : BaseMvcController
                 {
                     BlobContainerId = Guid.NewGuid(),
                     IsSageEnabled = viewModel.IsSageEnabled,
-                    MessageHtml = _messagePostProcessor.MessageToSafeHtml(viewModel.CategoryAlias, viewModel.ThreadId, viewModel.Message),
-                    MessageText = _messagePostProcessor.MessageToPlainText(viewModel.Message),
+                    MessageHtml = _messagePostProcessor.MessageToSafeHtml(viewModel.CategoryAlias, viewModel.ThreadId, viewModel.Message ?? string.Empty),
+                    MessageText = _messagePostProcessor.MessageToPlainText(viewModel.Message ?? string.Empty),
                     UserIpAddress = UserIpAddressBytes,
                     UserAgent = UserAgent.TryLeft(Defaults.MaxUserAgentLength),
                     CategoryAlias = viewModel.CategoryAlias,
                     ThreadId = viewModel.ThreadId,
-                    MentionedPosts = _messagePostProcessor.GetMentionedPosts(viewModel.Message),
+                    MentionedPosts = _messagePostProcessor.GetMentionedPosts(viewModel.Message ?? string.Empty),
                 };
 
                 if (postCreateRm.MessageText.Length > Defaults.MaxMessageTextLength)
@@ -169,7 +169,7 @@ public sealed class PostController : BaseMvcController
                     "Error creating post in category '{CategoryAlias}'. ThreadId: {ThreadId}, Message length: {MessageLength}, AttachmentsCount: {AttachmentsCount}",
                     categoryAlias,
                     viewModel.ThreadId,
-                    viewModel.Message.Length,
+                    viewModel.Message?.Length ?? 0,
                     viewModel.Attachments?.Count);
 
                 ViewBag.ErrorMessage = "Error occurred while creating a post. Please try again.";

--- a/Hikkaba.Web/DataAnnotations/AtLeastOnePropertyAttribute.cs
+++ b/Hikkaba.Web/DataAnnotations/AtLeastOnePropertyAttribute.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace Hikkaba.Web.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+internal sealed class AtLeastOnePropertyAttribute : ValidationAttribute
+{
+    public IReadOnlyList<string> PropertyList { get; }
+
+    public AtLeastOnePropertyAttribute(params string[] propertyList)
+    {
+        PropertyList = propertyList;
+    }
+
+    // see http://stackoverflow.com/a/1365669
+    public override object TypeId => this;
+
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        bool HasData(string propertyName)
+        {
+            var propertyInfo = value?.GetType().GetProperty(propertyName);
+
+            if (propertyInfo == null)
+            {
+                return false;
+            }
+
+            if (propertyInfo.PropertyType.IsAssignableTo(typeof(IFormFile)))
+            {
+                return propertyInfo.GetValue(value, null) is IFormFile { Length: > 0 };
+            }
+
+            if (propertyInfo.PropertyType.IsAssignableTo(typeof(IFormFileCollection)))
+            {
+                return propertyInfo.GetValue(value, null) is IFormFileCollection { Count: > 0 };
+            }
+
+            if (propertyInfo.PropertyType == typeof(string))
+            {
+                var stringValue = propertyInfo.GetValue(value, null) as string;
+                return !string.IsNullOrEmpty(stringValue);
+            }
+
+            if (propertyInfo.GetValue(value, null) != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        var errorMessage = ErrorMessage ?? $"At least one property must be set: {string.Join(", ", PropertyList)}";
+
+        return PropertyList.Any(HasData)
+            ? ValidationResult.Success
+            : new ValidationResult(
+                string.Format(CultureInfo.InvariantCulture, errorMessage, string.Join(", ", PropertyList)),
+                PropertyList);
+    }
+}

--- a/Hikkaba.Web/ViewModels/PostsViewModels/PostAnonymousCreateViewModel.cs
+++ b/Hikkaba.Web/ViewModels/PostsViewModels/PostAnonymousCreateViewModel.cs
@@ -5,18 +5,17 @@ using Microsoft.AspNetCore.Http;
 
 namespace Hikkaba.Web.ViewModels.PostsViewModels;
 
+[AtLeastOneProperty(nameof(Attachments), nameof(Message), ErrorMessage = "Message or attachment is required.")]
 public sealed class PostAnonymousCreateViewModel
 {
     [Required]
     [Display(Name = @"Sage")]
     public required bool IsSageEnabled { get; set; }
 
-    [Required]
     [DataType(DataType.MultilineText)]
-    [MinLength(1)]
     [MaxLength(Defaults.MaxMessageHtmlLength)]
     [Display(Name = @"Message")]
-    public required string Message { get; set; }
+    public string? Message { get; set; } = string.Empty;
 
     [Display(Name = @"Attachments")]
     [AllowedExtensions(Defaults.AllAllowedExtensions)]


### PR DESCRIPTION
Introduces `AtLeastOnePropertyAttribute` for model validation, ensuring at least one of the specified properties (message or attachment) is provided.
