### PR TITLE
Improves file validation message clarity

### DIFF
--- a/Hikkaba.Web/DataAnnotations/MaxFileCollectionSizeAttribute.cs
+++ b/Hikkaba.Web/DataAnnotations/MaxFileCollectionSizeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
+using Humanizer;
 using Microsoft.AspNetCore.Http;
 
 namespace Hikkaba.Web.DataAnnotations;
@@ -44,7 +46,7 @@ internal sealed class MaxFileCollectionSizeAttribute : ValidationAttribute
             var totalSize = formFileCollection.Sum(formFile => formFile.Length);
 
             if (totalSize > MaxFileCollectionSize)
-                return new ValidationResult($"Maximum allowed total file size: {MaxFileCollectionSize} bytes. Actual: {totalSize}.");
+                return new ValidationResult($"Total file size exceeds the limit. Maximum: {MaxFileCollectionSize.Bytes().Humanize(CultureInfo.InvariantCulture)}, Uploaded: {totalSize.Bytes().Humanize(CultureInfo.InvariantCulture)}.");
 
             return ValidationResult.Success;
         }

--- a/Hikkaba.Web/DataAnnotations/MaxFileCountAttribute.cs
+++ b/Hikkaba.Web/DataAnnotations/MaxFileCountAttribute.cs
@@ -38,7 +38,7 @@ internal sealed class MaxFileCountAttribute : ValidationAttribute
             var fileCount = formFileCollection.Count;
 
             if (fileCount > MaxFileCount)
-                return new ValidationResult($"Maximum allowed file count: {MaxFileCount}. Actual: {fileCount}.");
+                return new ValidationResult($"Too many files selected. Limit: {MaxFileCount}, Selected: {fileCount}.");
 
             return ValidationResult.Success;
         }

--- a/Hikkaba.Web/DataAnnotations/MaxFileSizeAttribute.cs
+++ b/Hikkaba.Web/DataAnnotations/MaxFileSizeAttribute.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Hikkaba.Shared.Extensions;
+using Humanizer;
 using Microsoft.AspNetCore.Http;
 
 namespace Hikkaba.Web.DataAnnotations;
@@ -38,7 +41,7 @@ internal sealed class MaxFileSizeAttribute : ValidationAttribute
         if (value is IFormFile formFile)
         {
             if (formFile.Length > MaxFileSize)
-                return new ValidationResult($"Maximum allowed file size: {MaxFileSize} bytes. Size of {formFile.FileName}: {formFile.Length}.");
+                return new ValidationResult($"File size exceeds the limit. Maximum: {MaxFileSize.Bytes().Humanize(CultureInfo.InvariantCulture)}. Size of \"{formFile.FileName.Cut(20)}\": {formFile.Length.Bytes().Humanize(CultureInfo.InvariantCulture)}.");
 
             return ValidationResult.Success;
         }
@@ -48,12 +51,12 @@ internal sealed class MaxFileSizeAttribute : ValidationAttribute
             foreach (var collectionItem in formFileCollection)
             {
                 if (collectionItem.Length > MaxFileSize)
-                    return new ValidationResult($"Maximum allowed file size: {MaxFileSize} bytes. Size of {collectionItem.FileName}: {collectionItem.Length}.");
+                    return new ValidationResult($"File size exceeds the limit. Maximum: {MaxFileSize.Bytes().Humanize(CultureInfo.InvariantCulture)}. Size of \"{collectionItem.FileName.Cut(20)}\": {collectionItem.Length.Bytes().Humanize(CultureInfo.InvariantCulture)}.");
             }
 
             return ValidationResult.Success;
         }
 
-        return new ValidationResult($"Unknown type.");
+        return new ValidationResult("Unknown type.");
     }
 }


### PR DESCRIPTION
Enhances the file validation error messages to be more user-friendly by displaying file sizes in a human-readable format and providing clearer explanations of the limits.

Also truncates long filenames in the error messages for better readability.
