### PR TITLE
Disables query logging in tests

### DIFF
--- a/Hikkaba.Tests.Integration/CustomAppFactory.cs
+++ b/Hikkaba.Tests.Integration/CustomAppFactory.cs
@@ -86,14 +86,18 @@ internal sealed class CustomAppFactory
                         options.EnableSensitiveDataLogging();
                     }
 
-                    options
-                        .UseSqlServer(_connectionString, ContextConfiguration.SqlServerOptionsAction)
-                        .LogTo((eventId, logLevel) => logLevel >= LogLevel.Trace,
+                    options.UseSqlServer(_connectionString, ContextConfiguration.SqlServerOptionsAction);
+
+                    var isQueryLoggingEnabled = bool.Parse("false");
+                    if (isQueryLoggingEnabled)
+                    {
+                        options.LogTo((eventId, logLevel) => logLevel >= LogLevel.Trace,
                             eventData =>
                             {
                                 TestLogUtils.WriteProgressMessage(eventData.ToString());
                                 TestLogUtils.WriteConsoleMessage(eventData.ToString());
                             });
+                    }
                 });
 
                 services.AddDataProtection(options => options

--- a/Hikkaba.Tests.Integration/Utils/TestDbUtils.cs
+++ b/Hikkaba.Tests.Integration/Utils/TestDbUtils.cs
@@ -27,12 +27,6 @@ internal static class TestDbUtils
     {
         var dbContextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseSqlServer(connectionString, ContextConfiguration.SqlServerOptionsAction)
-            .LogTo((eventId, logLevel) => logLevel >= LogLevel.Trace,
-                eventData =>
-                {
-                    TestLogUtils.WriteProgressMessage(eventData.ToString());
-                    TestLogUtils.WriteConsoleMessage(eventData.ToString());
-                })
             .Options;
         return new ApplicationDbContext(dbContextOptions);
     }

--- a/Hikkaba.Tests.Unit/CustomAppFactory.cs
+++ b/Hikkaba.Tests.Unit/CustomAppFactory.cs
@@ -107,13 +107,7 @@ internal sealed class CustomAppFactory
 
                     options
                         .UseInMemoryDatabase("HikkabaInMemoryDb")
-                        .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-                        .LogTo((eventId, logLevel) => logLevel >= LogLevel.Trace,
-                            eventData =>
-                            {
-                                TestLogUtils.WriteProgressMessage(eventData.ToString());
-                                TestLogUtils.WriteConsoleMessage(eventData.ToString());
-                            });
+                        .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning));
                 });
 
                 services.AddDataProtection(options => options


### PR DESCRIPTION
Removes query logging from integration and unit tests to reduce noise in test output.

Adds a configuration option to conditionally enable query logging in integration tests, currently disabled.
